### PR TITLE
export mdastToSlate/slateToMdast transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,5 @@ const ast = processor.runSync({
 const text = processor.stringify(ast);
 console.log(text);
 ```
+
+Transformer utilities `mdastToSlate` and `slateToMdast` are also exported for more fine-tuned control.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,5 @@ export { default as remarkToSlate } from "./plugins/remark-to-slate";
 export { default as slateToRemark } from "./plugins/slate-to-remark";
 export { default as slateToRemarkLegacy } from "./plugins/slate0.47-to-remark";
 export { default as remarkToSlateLegacy } from "./plugins/remark-to-slate0.47";
+export { mdastToSlate } from "./transformers/mdast-to-slate";
+export { slateToMdast } from "./transformers/slate-to-mdast";


### PR DESCRIPTION
In my application, I've built out a bunch of utility functions for converting between html, markdown, and slate. The least error-prone way to do this is to convert between syntax trees (i.e. html->hast->mdast->slate rather than html->hast->mdast->md->mdast->slate). For these kind of uses, providing the `mdastToSlate` and `slateToMdast` transformers directly would be a great help.