### PR TITLE
Type error about extending mdast

### DIFF
--- a/src/models/mdast.ts
+++ b/src/models/mdast.ts
@@ -3,29 +3,14 @@
 import type { Literal } from 'mdast'
 
 export * from 'mdast'
+export * from 'mdast-util-math/complex-types'
 
 export interface TOML extends Literal {
   type: "toml";
 }
 
-export interface Math extends Literal {
-  type: "math";
-}
-
-export interface InlineMath extends Literal {
-  type: "inlineMath";
-}
-
 declare module "mdast" {
   interface FrontmatterContentMap {
     toml: TOML
-  }
-
-  interface BlockContentMap {
-    math: Math
-  }
-
-  interface StaticPhrasingContentMap {
-    inlineMath: InlineMath
   }
 }

--- a/src/models/mdast.ts
+++ b/src/models/mdast.ts
@@ -1,75 +1,8 @@
 // ref: https://github.com/syntax-tree/mdast
 
-import type {
-  Parent,
-  Literal,
-  Root,
-  Paragraph,
-  Heading,
-  ThematicBreak,
-  Blockquote,
-  List,
-  ListItem,
-  Table,
-  TableRow,
-  TableCell,
-  HTML,
-  Code,
-  YAML,
-  Definition,
-  FootnoteDefinition,
-  Text,
-  Emphasis,
-  Strong,
-  Delete,
-  InlineCode,
-  Break,
-  Link,
-  Image,
-  LinkReference,
-  ImageReference,
-  Footnote,
-  FootnoteReference,
-  Resource,
-  Association,
-  Reference,
-  Alternative,
-} from "mdast";
-export type {
-  Parent,
-  Literal,
-  Root,
-  Paragraph,
-  Heading,
-  ThematicBreak,
-  Blockquote,
-  List,
-  ListItem,
-  Table,
-  TableRow,
-  TableCell,
-  HTML,
-  Code,
-  YAML,
-  Definition,
-  FootnoteDefinition,
-  Text,
-  Emphasis,
-  Strong,
-  Delete,
-  InlineCode,
-  Break,
-  Link,
-  Image,
-  LinkReference,
-  ImageReference,
-  Footnote,
-  FootnoteReference,
-  Resource,
-  Association,
-  Reference,
-  Alternative,
-};
+import type { Literal } from 'mdast'
+
+export * from 'mdast'
 
 export interface TOML extends Literal {
   type: "toml";
@@ -83,51 +16,16 @@ export interface InlineMath extends Literal {
   type: "inlineMath";
 }
 
-export type Content =
-  | TopLevelContent
-  | ListContent
-  | TableContent
-  | RowContent
-  | PhrasingContent;
+declare module "mdast" {
+  interface FrontmatterContentMap {
+    toml: TOML
+  }
 
-export type TopLevelContent =
-  | BlockContent
-  | FrontmatterContent
-  | DefinitionContent;
+  interface BlockContentMap {
+    math: Math
+  }
 
-export type BlockContent =
-  | Paragraph
-  | Heading
-  | ThematicBreak
-  | Blockquote
-  | List
-  | Table
-  | HTML
-  | Code
-  | Math;
-
-export type FrontmatterContent = YAML | TOML;
-
-export type DefinitionContent = Definition | FootnoteDefinition;
-
-export type ListContent = ListItem;
-
-export type TableContent = TableRow;
-
-export type RowContent = TableCell;
-
-export type PhrasingContent = StaticPhrasingContent | Link | LinkReference;
-
-export type StaticPhrasingContent =
-  | Text
-  | Emphasis
-  | Strong
-  | Delete
-  | HTML
-  | InlineCode
-  | Break
-  | Image
-  | ImageReference
-  | Footnote
-  | FootnoteReference
-  | InlineMath;
+  interface StaticPhrasingContentMap {
+    inlineMath: InlineMath
+  }
+}


### PR DESCRIPTION
I tried to extend the `FrontmatterContent` type to support json format.

```typescript
declare module "mdast" {
  interface FrontmatterContentMap {
    json: JSON;
  }
}

export interface JSON extends mdast.Literal {
  type: "json";
}
```
But the following code will give a typescript error.
```typescript
const buildJson = ({ type, value }: JSON) => {
  return {
    type,
    children: [{ text: value }],
  };
};

const vFile = unified()
      .use(remarkParse)
      .use(remarkFrontmatter, [
        { type: "json", fence: { open: "{", close: "}" } },
      ])
      .use(remarkToSlate, {
        overrides: {
          json: buildJson,
        },
      })
      .processSync("{\nkey: value\n}");
```
![image](https://user-images.githubusercontent.com/112480001/195988478-28371db9-86a2-4856-9516-4bab5f0977ad.png)

The reason for the problem is that although I extended the `FrontmatterContent ` type for the `mdast` library, a separate `FrontmatterContent` type was created and exported in the source code.

```typescript
// src/models/mdast.ts
export type FrontmatterContent = YAML | TOML;
```

So the "json" does not exist in mdast.Content["type"].

```typescript
// src/transformers/mdast-to-slate/index.ts
export type MdastBuilder<T extends string> = (
  node: T extends mdast.Content["type"]
    ? Extract<mdast.Content, { type: T }>
    : unknown,
  next: (children: any[]) => any
) => object | undefined;
```

The final node type is unknown, resulting in an error.

So I suggest that the source code use `declare mdoule` to extend the types in mdast, rather than creating separate types.